### PR TITLE
Add option to disable authncontext

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -52,6 +52,7 @@ module.exports = {
       // SAML_NAMEID_FIELD: undefined,
       // SAML_NAMEID_FORMAT: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
       // SAML_SP_AUDIENCE: undefined,
+      // SAML_DISABLE_CONTEXT: true,
       // SESSION_SECRET: 'keyboard cat',
       // SP_KEY_ALGO: 'sha256',
       // TRUST_PROXY: undefined,

--- a/lib/features/login/presentation/routes/saml.js
+++ b/lib/features/login/presentation/routes/saml.js
@@ -54,6 +54,7 @@ const samlOptions = {
   idpIssuer: process.env.SAML_IDP_ENTITY_ID || process.env.SAML_IDP_ISSUER || undefined,
   audience: process.env.SAML_SP_AUDIENCE || undefined,
   authnContext: process.env.SAML_AUTHN_CONTEXT || undefined,
+  disableRequestedAuthnContext: process.env.SAML_DISABLE_CONTEXT || undefined,
   decryptionPvk: fs.readFileSync(container.resolve('serviceKey'), 'utf-8'),
   privateCert: fs.readFileSync(container.resolve('serviceKey'), 'utf-8'),
   signatureAlgorithm: process.env.SP_KEY_ALGO || 'sha256',


### PR DESCRIPTION
Add option to disable authncontext to allow Azure AD SAML to support both X509 and passwords. AAD doesn't support arrays so the default authncontext don't end with a AADSTS7500522 - empty URI.
