### PR TITLE
Dockerfile: Switch from ENTRYPOINT to CMD

### DIFF
--- a/containers/auth-svc/Dockerfile
+++ b/containers/auth-svc/Dockerfile
@@ -25,4 +25,4 @@ EXPOSE ${PORT}
 
 HEALTHCHECK CMD curl -k -f -s -I http://localhost:${PORT}/ || exit 1
 
-ENTRYPOINT [ "node", "bin/www" ]
+CMD [ "node", "bin/www" ]

--- a/containers/hub/Dockerfile
+++ b/containers/hub/Dockerfile
@@ -42,4 +42,4 @@ ENV NODE_ENV development
 ENV PORT 3000
 ENV SVC_BASE_URI "https://localhost:3000"
 EXPOSE ${PORT}
-ENTRYPOINT ["./helix-auth-svc"]
+CMD ["./helix-auth-svc"]


### PR DESCRIPTION
ENTRYPOINT and CMD are nearly the same in practice, but CMD can be overridden easily unlike ENTRYPOINT.

Use case:

This allows us to better override the CMD when doing things like running tests with the Dockerfile.


In the meantime (after making this PR) we have extended the Dockerfile as such:

```
FROM perforce/helix-auth-svc:2021.1

ENTRYPOINT [ "" ]
CMD [ "./helix-auth-svc" ]
```